### PR TITLE
Fix broken volunteer UofR logo and automate gh-pages deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,45 @@
+name: Build and Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Only one deploy at a time; a newer push supersedes an in-flight one.
+concurrency:
+  group: gh-pages-deploy
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        # react-scripts treats lint warnings as errors when CI=true, which is
+        # the default on Actions. Keep warnings non-fatal so a deploy is never
+        # blocked by one.
+        env:
+          CI: false
+        run: npm run build
+
+      - name: Publish to gh-pages branch
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build
+          publish_branch: gh-pages

--- a/src/components/PastExperience/WorkExperience.js
+++ b/src/components/PastExperience/WorkExperience.js
@@ -127,9 +127,9 @@ const VOLUNTEER_EXPERIENCE = [
     status: "Volunteer",
     href: "https://dandyhacks.net",
     logo: {
-      src: `${process.env.PUBLIC_URL}/HackathonLogo.png`,
-      width: 640,
-      height: 640,
+      src: "https://upload.wikimedia.org/wikipedia/en/7/76/University_of_Rochester_logo.svg",
+      width: 690,
+      height: 190,
     },
   },
   {


### PR DESCRIPTION
## What

- The **University of Rochester / Hackathon Organizer** volunteer card pointed at `${process.env.PUBLIC_URL}/HackathonLogo.png`. That file exists in `public/` on `main`, but it was never included in a deploy — the published `gh-pages` tree has no `HackathonLogo.png`, so the image 404s on the live site. It now uses the same University of Rochester logo already used by the two other UofR entries in `PREVIOUS_EXPERIENCE`.
- Added `.github/workflows/deploy.yml`: builds the CRA app and publishes `build/` to the `gh-pages` branch on every push to `main` (plus manual `workflow_dispatch`). This removes the manual `npm run build && npm run deploy` step that let the deployed site drift from the source in the first place.

## Notes

- The workflow publishes to the same `gh-pages` branch the site is already served from, so no GitHub Pages settings change is needed.
- `CI: false` is set on the build step because `react-scripts` treats lint warnings as errors when `CI=true` (the Actions default), which would otherwise block a deploy over a warning.
- `public/HackathonLogo.png` was left in place — unused by this component now, but harmless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)